### PR TITLE
Upgrade to Go 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/TV4/vimond
 
-go 1.16
+go 1.25.4
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
This PR upgrades the project to Go 1.25.4, the latest stable version as of November 2025.

Changes:
- Updated go.mod to use Go 1.25.4
- Updated Dockerfiles with Go 1.25.4
- Updated GitHub Actions workflows with Go 1.25.4
- Ran go mod tidy