### PR TITLE
Update dependabot to run monthly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
This PR updates the dependabot configuration to run on a monthly schedule instead of weekly.